### PR TITLE
Removed explicit call to dotenv. 

### DIFF
--- a/web/serve.py
+++ b/web/serve.py
@@ -3,16 +3,10 @@ from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
 import os
 
-# The first thing we do is inject necessary environment dependencies.
-# Note that this will not overwrite existing environment variables.
-import dotenv
-dotenv.load_dotenv()
-
 app = Flask(__name__)
 
 app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('SQLALCHEMY_DATABASE_URI')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-
 db = SQLAlchemy(app)
 
 


### PR DESCRIPTION
Flask does this automatically for us.

See [here](https://github.com/pallets/flask/blob/c5c8bbc7f699de6b81ebd9893dc0a2289ae688dc/flask/cli.py\#L35)