### PR TITLE
Flask and Flask_SQLAlchemy requirements

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -3,3 +3,5 @@ chardet==3.0.4
 idna==2.8
 requests==2.21.0
 urllib3==1.24.2
+Flask==1.0.2
+Flask-SQLAlchemy==2.3.2


### PR DESCRIPTION
The flask and flask_sqlalchemy modules were required in order for the
integration test to run smoothly. I have added these to the
requirements-integration.txt file